### PR TITLE
Remove unused import of pandas.Categorical

### DIFF
--- a/docs/advanced-analytics/tutorials/use-python-revoscalepy-to-create-model.md
+++ b/docs/advanced-analytics/tutorials/use-python-revoscalepy-to-create-model.md
@@ -78,7 +78,6 @@ from revoscalepy import RxComputeContext, RxInSqlServer, RxSqlServerData
 from revoscalepy import rx_lin_mod, rx_predict, rx_summary
 from revoscalepy import RxOptions, rx_import
 
-from pandas import Categorical
 import os
 
 def test_linmod_sql():


### PR DESCRIPTION
The sample code imports pandas.Categorial.  However, this is never used.  This patch removes that imp ort